### PR TITLE
Fix missing managerId in analytics

### DIFF
--- a/app/api/fpl-data/[id]/route.ts
+++ b/app/api/fpl-data/[id]/route.ts
@@ -62,6 +62,7 @@ interface FPLBootstrap {
 
 // Production-ready demo data
 const DEMO_DATA: FPLData = {
+  managerId: "demo",
   managerName: "Demo Manager",
   teamName: "Demo Team FC",
   totalPoints: 2156,
@@ -226,7 +227,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     if (managerId === "demo" || managerId === "1") {
       monitor.trackApiCall(endpoint, Date.now() - startTime, true)
       monitor.trackUserAction("demo_mode_used")
-      return NextResponse.json(DEMO_DATA, {
+      return NextResponse.json({ ...DEMO_DATA, managerId }, {
         headers: {
           "Cache-Control": "public, max-age=3600",
           "X-Response-Time": `${Date.now() - startTime}ms`,
@@ -275,6 +276,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
       historyData.status === "fulfilled" ? historyData.value : { current: [], chips: [] },
       transfersData.status === "fulfilled" ? transfersData.value : { length: 38 },
       bootstrapData.status === "fulfilled" ? bootstrapData.value : { elements: [], events: [] },
+      managerId,
     )
 
     // Validate processed data
@@ -340,6 +342,9 @@ function getClientIP(request: NextRequest): string {
 function validateFPLData(data: FPLData): boolean {
   try {
     return (
+      typeof data.managerId === "string" &&
+      data.managerId.length > 0 &&
+      data.managerId.length <= 100 &&
       typeof data.managerName === "string" &&
       data.managerName.length > 0 &&
       data.managerName.length <= 100 &&
@@ -394,6 +399,7 @@ function processFPLData(
   history: FPLHistory,
   transfers: FPLTransfers,
   bootstrap: FPLBootstrap,
+  managerId: string,
 ): FPLData {
   const current = history.current || []
 
@@ -594,6 +600,7 @@ function processFPLData(
 
   // Return validated and sanitized data
   return {
+    managerId,
     managerName: sanitizeString(`${manager.player_first_name} ${manager.player_last_name}`),
     teamName: sanitizeString(manager.name || "FPL Team"),
     totalPoints: Math.max(0, Math.min(5000, manager.summary_overall_points)),

--- a/components/retro-game-experience.tsx
+++ b/components/retro-game-experience.tsx
@@ -301,8 +301,8 @@ export default function RetroGameExperience({ data, onRestart }: RetroGameExperi
 
   // Track game start
   useEffect(() => {
-    trackEvent("game_start", { manager_id: data.manager_id })
-  }, [data.manager_id, trackEvent])
+    trackEvent("game_start", { manager_id: data.managerId })
+  }, [data.managerId, trackEvent])
 
   if (showFinal) {
     return <RetroFinalCard data={data} onRestart={onRestart} onBack={() => setShowFinal(false)} />

--- a/types/fpl.ts
+++ b/types/fpl.ts
@@ -1,4 +1,5 @@
 export interface FPLData {
+  managerId: string
   managerName: string
   teamName: string // Added team name field
   totalPoints: number


### PR DESCRIPTION
## Summary
- include `managerId` in FPLData
- return the ID from the FPL API endpoint
- track game_start with the correct managerId

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module / type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_683c96b3fd6c832dbcd29418f02e0f0c